### PR TITLE
fix(locales): support em and en dashes in date range patterns

### DIFF
--- a/src/locales/de-DE/profile.ts
+++ b/src/locales/de-DE/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for de-DE.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-—–](?:\d{1,2}). (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2}).(?:-|–|—)(?:\d{1,2}). (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/de-DE/profile.ts
+++ b/src/locales/de-DE/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for de-DE.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-](?:\d{1,2}). (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2}).[-—–](?:\d{1,2}). (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/el-GR/profile.ts
+++ b/src/locales/el-GR/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for el-GR.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-|–)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/en-LR/profile.ts
+++ b/src/locales/en-LR/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 

--- a/src/locales/en/profile.ts
+++ b/src/locales/en/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–)(?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 

--- a/src/locales/es-ES/profile.ts
+++ b/src/locales/es-ES/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for es-ES.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-–](?:\d{1,2}) de (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) de (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/es-LSE/profile.ts
+++ b/src/locales/es-LSE/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for es-LSE.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-–](?:\d{1,2}) de (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) de (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/et-EE/profile.ts
+++ b/src/locales/et-EE/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for et-EE.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-–](?:\d{1,2}). (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2}).(?:-|–|—)(?:\d{1,2}). (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-–](?:\d{1,2}).? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})[-–](?:\d{1,2}).? (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}).(?:-|–|—)(?:\d{1,2}).? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}).? (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/fi-FI/profile.ts
+++ b/src/locales/fi-FI/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for fi-FI.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-–](?:\d{1,2}). (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2}).(?:-|–|—)(?:\d{1,2}). (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/hi-IN/profile.ts
+++ b/src/locales/hi-IN/profile.ts
@@ -4,12 +4,12 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for hi-IN.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>(?:${MONTH_NAME})+)`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>(?:${MONTH_NAME})+)`,
   String.raw`\b(?<day>\d{1,2}) (?<month>(?:${MONTH_NAME})+)`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>(?:${MONTH_NAME})+), (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>(?:${MONTH_NAME})+), (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>(?:${MONTH_NAME})+), (?<year>\d{4})`,
 ];
 

--- a/src/locales/hi-IN/profile.ts
+++ b/src/locales/hi-IN/profile.ts
@@ -4,12 +4,12 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for hi-IN.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>(?:${MONTH_NAME})+)`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>(?:${MONTH_NAME})+)`,
   String.raw`\b(?<day>\d{1,2}) (?<month>(?:${MONTH_NAME})+)`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>(?:${MONTH_NAME})+), (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>(?:${MONTH_NAME})+), (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>(?:${MONTH_NAME})+), (?<year>\d{4})`,
 ];
 

--- a/src/locales/ilo-PH/profile.ts
+++ b/src/locales/ilo-PH/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 

--- a/src/locales/it-IT/profile.ts
+++ b/src/locales/it-IT/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for it-IT.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:º)?[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:º)?[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:º)?[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME})[-](?:\d{1,2})(?:º)? (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:º)?[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME})[-—–](?:\d{1,2})(?:º)? (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/it-IT/profile.ts
+++ b/src/locales/it-IT/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for it-IT.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:º)?[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:º)?(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:º)?[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME})[-—–](?:\d{1,2})(?:º)? (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:º)?(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2})(?:º)? (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2})(?:º)? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/mg-MG/profile.ts
+++ b/src/locales/mg-MG/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for mg-MG.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-|–)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-|–)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/mg-TND/profile.ts
+++ b/src/locales/mg-TND/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for mg-TND.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/mg-TNK/profile.ts
+++ b/src/locales/mg-TNK/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for mg-TNK.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/mg-TTM/profile.ts
+++ b/src/locales/mg-TTM/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for mg-TTM.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/mg-VZ/profile.ts
+++ b/src/locales/mg-VZ/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for mg-VZ.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})(?:-)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/ms-MY/profile.ts
+++ b/src/locales/ms-MY/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ms-MY.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/ms-MY/profile.ts
+++ b/src/locales/ms-MY/profile.ts
@@ -4,12 +4,12 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ms-MY.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];

--- a/src/locales/nl-NL/profile.ts
+++ b/src/locales/nl-NL/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for nl-NL.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/nl-NL/profile.ts
+++ b/src/locales/nl-NL/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for nl-NL.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/pl-PL/profile.ts
+++ b/src/locales/pl-PL/profile.ts
@@ -4,7 +4,7 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for pl-PL.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 

--- a/src/locales/pt-LSB/profile.ts
+++ b/src/locales/pt-LSB/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for pt-LSB.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-–](?:\d{1,2}) de (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) de (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})[-—–](?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
 ];
 

--- a/src/locales/pt-LSB/profile.ts
+++ b/src/locales/pt-LSB/profile.ts
@@ -9,8 +9,8 @@ const mwbDatePatternOptions = [
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})[-](?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})[-—–](?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
 ];
 

--- a/src/locales/pt-POR/profile.ts
+++ b/src/locales/pt-POR/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for pt-POR.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-–](?:\d{1,2}) de (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) de (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})[-—–](?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
 ];
 

--- a/src/locales/pt-POR/profile.ts
+++ b/src/locales/pt-POR/profile.ts
@@ -9,8 +9,8 @@ const mwbDatePatternOptions = [
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})[-](?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME})[-—–](?:\d{1,2})?(?:.º)? de (?:${MONTH_NAME}) de (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) de (?<month>${MONTH_NAME}) de (?<year>\d{4})`,
 ];
 

--- a/src/locales/ro-RO/profile.ts
+++ b/src/locales/ro-RO/profile.ts
@@ -4,12 +4,12 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ro-RO.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];

--- a/src/locales/ro-RO/profile.ts
+++ b/src/locales/ro-RO/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ro-RO.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/ru-RU/profile.ts
+++ b/src/locales/ru-RU/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ru-RU.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/ru-RU/profile.ts
+++ b/src/locales/ru-RU/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ru-RU.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/rw-RW/profile.ts
+++ b/src/locales/rw-RW/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for rw-RW.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/rw-RW/profile.ts
+++ b/src/locales/rw-RW/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for rw-RW.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/sl-SI/profile.ts
+++ b/src/locales/sl-SI/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for sl-SI.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-–](?:\d{1,2}). (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2}).(?:-|–|—)(?:\d{1,2}). (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2}).[-–](?:\d{1,2}).? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})[-–](?:\d{1,2}).? (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}).(?:-|–|—)(?:\d{1,2}).? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}).? (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}). (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/sv-SE/profile.ts
+++ b/src/locales/sv-SE/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for sv-SE.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/sv-SE/profile.ts
+++ b/src/locales/sv-SE/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for sv-SE.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/sw-KE/profile.ts
+++ b/src/locales/sw-KE/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 

--- a/src/locales/tl-PH/profile.ts
+++ b/src/locales/tl-PH/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 

--- a/src/locales/tr-TR/profile.ts
+++ b/src/locales/tr-TR/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for tr-TR.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/tr-TR/profile.ts
+++ b/src/locales/tr-TR/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for tr-TR.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/tw-TW/profile.ts
+++ b/src/locales/tw-TW/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 

--- a/src/locales/ty-PF/profile.ts
+++ b/src/locales/ty-PF/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ty-PF.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) no (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) no (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? no (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) no (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? no (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) no (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})(?:,)? (?<year>\d{4})`,
 ];
 

--- a/src/locales/ty-PF/profile.ts
+++ b/src/locales/ty-PF/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for ty-PF.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) no (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) no (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? no (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})[-](?:\d{1,2}) no (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? no (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) no (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) no (?<month>${MONTH_NAME})(?:,)? (?<year>\d{4})`,
 ];
 

--- a/src/locales/uk-UA/profile.ts
+++ b/src/locales/uk-UA/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for uk-UA.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/uk-UA/profile.ts
+++ b/src/locales/uk-UA/profile.ts
@@ -4,13 +4,13 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for uk-UA.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
-  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})[-—–](?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}) (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME})(?:-|–|—)(?:\d{1,2}) (?:${MONTH_NAME}) (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}) (?<year>\d{4})`,
 ];
 

--- a/src/locales/vi-VN/profile.ts
+++ b/src/locales/vi-VN/profile.ts
@@ -4,12 +4,12 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for vi-VN.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-](?:\d{1,2})? (?<month>${MONTH_NAME}\s\d{1,2}) năm (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}\s\d{1,2}) năm (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2}) năm (?<year>\d{4})`,
 ];
 

--- a/src/locales/vi-VN/profile.ts
+++ b/src/locales/vi-VN/profile.ts
@@ -4,12 +4,12 @@ import { MONTH_NAME } from '../../constants/index.js';
 // Language profile override for vi-VN.
 
 const mwbDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2})`,
 ];
 
 const wDatePatternOptions = [
-  String.raw`\b(?<day>\d{1,2})[-—–](?:\d{1,2})? (?<month>${MONTH_NAME}\s\d{1,2}) năm (?<year>\d{4})`,
+  String.raw`\b(?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})? (?<month>${MONTH_NAME}\s\d{1,2}) năm (?<year>\d{4})`,
   String.raw`\b(?<day>\d{1,2}) (?<month>${MONTH_NAME}\s\d{1,2}) năm (?<year>\d{4})`,
 ];
 

--- a/src/locales/wes-PGW/profile.ts
+++ b/src/locales/wes-PGW/profile.ts
@@ -6,8 +6,8 @@ import { MONTH_NAME } from '../../constants/index.js';
 const mwbDatePatternOptions = [String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})`];
 
 const wDatePatternOptions = [
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:\d{1,2})?, (?<year>\d{4})`,
-  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})[-–](?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:\d{1,2})?, (?<year>\d{4})`,
+  String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2})(?:-|–|—)(?:${MONTH_NAME}) (?:\d{1,2}), (?<year>\d{4})`,
   String.raw`(?<month>${MONTH_NAME}) (?<day>\d{1,2}), (?<year>\d{4})`,
 ];
 


### PR DESCRIPTION
This PR fixes date range parsing failures caused by dash character mismatches across locale profiles.

## What changed

All locale profiles that used a date range separator now use the uniform `(?:-|–|—)` alternation, which matches:
- `-` hyphen-minus
- `–` en-dash (U+2013)
- `—` em-dash (U+2014)

Each locale profile file was updated individually — no shared constants were introduced, keeping each file's language settings self-contained.

## Files changed

34 locale profiles updated: `de-DE`, `el-GR`, `en`, `en-LR`, `es-ES`, `es-LSE`, `et-EE`, `fi-FI`, `hi-IN`, `ht-HT`, `ilo-PH`, `it-IT`, `mg-MG`, `mg-TND`, `mg-TNK`, `mg-TTM`, `mg-VZ`, `ms-MY`, `nl-NL`, `pl-PL`, `pt-LSB`, `pt-POR`, `ro-RO`, `ru-RU`, `rw-RW`, `sl-SI`, `sv-SE`, `sw-KE`, `tl-PH`, `tr-TR`, `tw-TW`, `ty-PF`, `uk-UA`, `vi-VN`, `wes-PGW`

Fixes https://github.com/sws2apps/organized-app/issues/5229

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)